### PR TITLE
[Feat/#16] 사용자 로그인 및 회원가입 기능 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,11 @@ jobs:
         run: yarn install
       
       - name: Generate build
+        env:
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_OAUTH_KAKAO_REST_API_KEY: ${{ secrets.VITE_OAUTH_KAKAO_REST_API_KEY }}
+          VITE_OAUTH_KAKAO_CLIENT_SECRET_CODE: ${{ secrets.VITE_OAUTH_KAKAO_CLIENT_SECRET_CODE }}
+          VITE_OAUTH_KAKAO_REDIRECT_URI: ${{ secrets.VITE_OAUTH_KAKAO_REDIRECT_URI }}
         run: yarn build
       
       - name: Deploy

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
     "lint:fix": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --fix"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.51.23",
     "axios": "1.7.3",
     "core-js": "^3.28.0",
     "p5": "^1.9.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "^6.8.1",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@types/node": "^20.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,16 @@
 // dependencies
 import { Router } from "@/routes"
 
-const App: React.FC = () => {
-  return <Router></Router>
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+const queryClient = new QueryClient()
+
+const App = (): React.ReactElement => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Router></Router>
+    </QueryClientProvider>
+  )
 }
 
 export default App

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,87 @@
+// src/api/auth.ts
+import axiosInstance, { setAccessToken } from "@/api/axiosInstance"
+import qs from "qs"
+
+const REST_API_KEY = import.meta.env.VITE_OAUTH_KAKAO_REST_API_KEY
+const CLIENT_SECRET = import.meta.env.VITE_OAUTH_KAKAO_CLIENT_SECRET_CODE
+const REDIRECT_URI = import.meta.env.VITE_OAUTH_KAKAO_REDIRECT_URI
+
+export interface authUser {
+  uid: number
+  nickname: string
+  accessToken: string
+}
+
+export interface oauthUser {
+  nickname: string
+}
+
+export const oauth = async (code: string): Promise<string> => {
+  const formData = {
+    grant_type: "authorization_code",
+    client_id: REST_API_KEY,
+    client_secret: CLIENT_SECRET,
+    redirect_uri: REDIRECT_URI,
+    code,
+  }
+
+  try {
+    const res = await axiosInstance.post(`https://kauth.kakao.com/oauth/token?${qs.stringify(formData)}`, null, {
+      headers: { "Content-type": "application/x-www-form-urlencoded" },
+    })
+    return res.data.access_token
+  } catch (e) {
+    throw e
+  }
+}
+
+export const getOauthUser = async (accessToken: string): Promise<oauthUser> => {
+  const kakaoUser = await axiosInstance.get(`https://kapi.kakao.com/v2/user/me`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+  const { nickname } = kakaoUser.data.kakao_account.profile
+
+  return { nickname }
+}
+
+export const signIn = async (_accessToken: string): Promise<authUser> => {
+  try {
+    const res = await axiosInstance.post(`/oauth/kakao/sign-in`, { accessToken: _accessToken })
+    const { uid, nickname, accessToken } = res.data.data
+
+    // 로그인 성공 후 엑세스 토큰을 설정
+    setAccessToken(accessToken)
+
+    return { uid, nickname, accessToken }
+  } catch (e) {
+    throw e
+  }
+}
+
+export const signUp = async (_accessToken: string): Promise<authUser> => {
+  try {
+    const res = await axiosInstance.post(`/oauth/kakao/sign-up`, { accessToken: _accessToken })
+    const { uid, nickname, accessToken } = res.data.data
+
+    // 회원가입 성공 후 엑세스 토큰을 설정
+    setAccessToken(accessToken)
+
+    return { uid, nickname, accessToken }
+  } catch (e) {
+    throw e
+  }
+}
+
+export const getIsSignUp = async (accessToken: string): Promise<boolean> => {
+  try {
+    const res = await axiosInstance.get(`/oauth/kakao/sign-up/check`, {
+      params: { accessToken },
+    })
+    console.log(res.data)
+    return res.data.data.isExistsUser
+  } catch (e) {
+    throw e
+  }
+}

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,0 +1,31 @@
+// src/services/axiosInstance.ts
+import axios from "axios"
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+const axiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+})
+
+// localStorage에서 토큰 가져오기
+const token = localStorage.getItem("accessToken")
+if (token) {
+  axiosInstance.defaults.headers.common["Authorization"] = `Bearer ${token}`
+}
+
+// 엑세스 토큰 설정 함수
+export const setAccessToken = (token: string) => {
+  axiosInstance.defaults.headers.common["Authorization"] = `Bearer ${token}`
+  localStorage.setItem("accessToken", token)
+}
+
+// 엑세스 토큰 제거 함수
+export const clearAccessToken = () => {
+  delete axiosInstance.defaults.headers.common["Authorization"]
+  localStorage.removeItem("accessToken")
+}
+
+export default axiosInstance

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./auth"

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -50,22 +50,22 @@ export default function Camera(props: CameraProps): React.ReactElement {
         position: "relative",
       }}
     >
-    <div style={{ position: "relative", width: "100%", height: "100%" }}>
-      <video
-        className="rounded-lg"
-        ref={videoRef}
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          width: "100%",
-          height: "100%",
-          objectFit: "fill",
-          transform: "scaleX(-1)", // 비디오를 좌우 반전시키는 CSS 속성 추가
-        }}
-      />
-    </div>
-    <canvas
+      <div style={{ position: "relative", width: "100%", height: "100%" }}>
+        <video
+          className="rounded-lg"
+          ref={videoRef}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            objectFit: "fill",
+            transform: "scaleX(-1)", // 비디오를 좌우 반전시키는 CSS 속성 추가
+          }}
+        />
+      </div>
+      <canvas
         ref={canvasRef}
         width="1280"
         height="720"

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -2,6 +2,8 @@ import MainCraftIcon from "public/icons/posture-craft-side-nav-icon.svg?react"
 import MonitoringIcon from "public/icons/side-nav-monitor-icon.svg?react"
 import AnalysisIcon from "public/icons/side-nav-analysis-icon.svg?react"
 import CrewIcon from "public/icons/side-nav-crew-icon.svg?react"
+import { useAuthStore } from "@/store/AuthStore"
+import { useEffect } from "react"
 
 const navItems = [
   {
@@ -25,6 +27,8 @@ const navItems = [
 const footerLinks = ["이용약관", "의견보내기", "로그아웃"]
 
 export default function SideNav() {
+  const nickname = useAuthStore((state) => state.user?.nickname)
+
   return (
     <aside className="w-[224px] flex-none bg-[#1C1D20]">
       <div className="flex h-full flex-col justify-between text-white">
@@ -40,7 +44,7 @@ export default function SideNav() {
           <div className="pl-6 pt-2">
             <div className="text-sm text-gray-400">바른자세 똑딱똑딱</div>
             <div>
-              <span className="text-sm font-bold">조하은</span>
+              <span className="text-sm font-bold">{nickname}</span>
               <span className="text-sm text-gray-400"> 님</span>
             </div>
           </div>

--- a/src/constants/routes.json
+++ b/src/constants/routes.json
@@ -2,5 +2,6 @@
   "MONITORING": "/monitoring",
   "LOGIN": "/login",
   "AUTH" : "/auth",
-  "SOCKET": "/socket"
+  "SOCKET": "/socket",
+  "HOME" : "/home"
 }

--- a/src/hooks/useAuthMutation.ts
+++ b/src/hooks/useAuthMutation.ts
@@ -1,0 +1,61 @@
+import { authUser, getIsSignUp, getOauthUser, oauth, oauthUser, signIn, signUp } from "@/api"
+import { useMutation, UseMutationResult } from "@tanstack/react-query"
+
+export const useOauth = (): UseMutationResult<string, unknown, string, unknown> => {
+  return useMutation({
+    mutationFn: (code: string) => {
+      return oauth(code)
+    },
+    onSuccess: (data) => {
+      console.log(data)
+    },
+  })
+}
+
+export const useGetOauthUser = (): UseMutationResult<oauthUser, unknown, string, unknown> => {
+  return useMutation({
+    mutationFn: (accessToken: string) => getOauthUser(accessToken),
+    onSuccess: (data) => {
+      console.log("Oauth user data:", data)
+    },
+    onError: (error) => {
+      console.error("Error fetching oauth user:", error)
+    },
+  })
+}
+
+export const useSignIn = (): UseMutationResult<authUser, unknown, string, unknown> => {
+  return useMutation({
+    mutationFn: (_accessToken: string) => signIn(_accessToken),
+    onSuccess: (data) => {
+      console.log("User signed in:", data)
+    },
+    onError: (error) => {
+      console.error("Error signing in:", error)
+    },
+  })
+}
+
+export const useSignUp = (): UseMutationResult<authUser, unknown, string, unknown> => {
+  return useMutation({
+    mutationFn: (_accessToken: string) => signUp(_accessToken),
+    onSuccess: (data) => {
+      console.log("User signed up:", data)
+    },
+    onError: (error) => {
+      console.error("Error signing up:", error)
+    },
+  })
+}
+
+export const useGetIsSignUp = (): UseMutationResult<boolean, unknown, string, unknown> => {
+  return useMutation({
+    mutationFn: (accessToken: string) => getIsSignUp(accessToken),
+    onSuccess: (data) => {
+      console.log("User signup status:", data)
+    },
+    onError: (error) => {
+      console.error("Error checking signup status:", error)
+    },
+  })
+}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,75 +1,71 @@
 import { useEffect, useState } from "react"
-import axios from "axios"
 import { useNavigate } from "react-router-dom"
-import qs from "qs"
-
-const REST_API_KEY = "84b401e74d5a879d3fedfa7ba4366c68"
-const REDIRECT_URI = "http://localhost:3000/auth"
-const KAKAO_CLIENT_SECRET = "KlMbFCPi0ZAP8lMJEO3IDAsSVN5BoA2x"
+import Login from "@/components/Login"
+import { useOauth, useSignUp, useSignIn, useGetIsSignUp } from "@/hooks/useAuthMutation"
+import RoutePath from "@/constants/routes.json"
+import { useAuthStore } from "@/store/AuthStore"
 
 const AuthPage: React.FC = () => {
-  const [accessToken, setAccessToken] = useState("")
-
   const navigate = useNavigate()
 
-  const getToken = async (): Promise<string> => {
-    const code = new URL(window.location.href).searchParams.get("code")
+  const oauthMutation = useOauth()
+  const getIsSignUpMutation = useGetIsSignUp()
+  const signUpMutation = useSignUp()
+  const signInMutation = useSignIn()
 
-    const formData = {
-      grant_type: "authorization_code",
-      client_id: REST_API_KEY,
-      client_secret: KAKAO_CLIENT_SECRET,
-      redirect_uri: REDIRECT_URI,
-      code,
-    }
+  const [isLoading, setIsLoading] = useState(true)
+  const [isError, setIsError] = useState(false)
 
-    const {
-      data: { access_token },
-    } = await axios
-      .post(`https://kauth.kakao.com/oauth/token?${qs.stringify(formData)}`, null, {
-        headers: { "Content-type": "application/x-www-form-urlencoded" },
-      })
-      .then((res) => {
-        return res
-      })
-
-    setAccessToken(access_token)
-    return access_token
-  }
-
-  const getServiceToken = async (_accessToken: string): Promise<any> => {
-    const res = await axios.post("https://api.alignlab.site/api/v1/oauth/kakao/sign-in", { _accessToken })
-
-    return res
-  }
-
-  const getIsSignUp = async (_accessToken: string): Promise<boolean> => {
-    const res = await axios.get(
-      `https://api.alignlab.site/api/v1/oauth/kakao/sign-up/check?accessToken=${_accessToken}`
-    )
-
-    return res.data.isExistsUser
-  }
+  const setUser = useAuthStore((state) => state.setUser)
 
   useEffect(() => {
-    getToken()
-      .then((res) => {
-        if (res) {
-          // localStorage.setItem("token", JSON.stringify(res.data.access_token))
-          navigate("/")
+    const authenticate = async (): Promise<void> => {
+      try {
+        const code = new URL(window.location.href).searchParams.get("code")
+
+        if (!code) {
+          navigate(RoutePath.HOME)
+          return
         }
-      })
-      .catch((err) => console.log(err))
+
+        const _accessToken = await oauthMutation.mutateAsync(code)
+
+        const isUserSignedUp = await getIsSignUpMutation.mutateAsync(_accessToken)
+
+        if (!isUserSignedUp) {
+          await signUpMutation.mutateAsync(_accessToken)
+        }
+
+        const { uid, nickname, accessToken } = await signInMutation.mutateAsync(_accessToken)
+
+        // AuthStore에 사용자 정보와 토큰 저장
+        setUser({ uid, nickname }, accessToken)
+
+        setIsLoading(false)
+        navigate(RoutePath.MONITORING)
+      } catch (error) {
+        console.error("Error during authentication process:", error)
+        setIsLoading(false)
+        setIsError(true)
+      }
+    }
+
+    authenticate()
   }, [])
 
-  useEffect(() => {
-    if (accessToken) {
-      getIsSignUp(accessToken)
-      getServiceToken(accessToken)
-    }
-  }, [accessToken])
-
-  return <div>auth page</div>
+  return (
+    <div>
+      <Login />
+      {isLoading ? (
+        "Processing..."
+      ) : (
+        <>
+          {isError && <div>An error occurred</div>}
+          {signInMutation.isSuccess && <div>Login successful!</div>}
+        </>
+      )}
+    </div>
+  )
 }
 
 export default AuthPage

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,34 @@
+import MainCraftIcon from "public/icons/posture-craft-side-nav-icon.svg?react"
+import { useEffect } from "react"
+
+const REST_API_KEY = import.meta.env.VITE_OAUTH_KAKAO_REST_API_KEY
+const REDIRECT_URI = import.meta.env.VITE_OAUTH_KAKAO_REDIRECT_URI
+const LOGIN_LINK = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`
+
+const HomePage: React.FC = () => {
+  const loginHandler = (): void => {
+    window.location.href = LOGIN_LINK
+  }
+
+  return (
+    <div className="w-[1440px]">
+      {/* header */}
+      <div className="flex w-full bg-white px-[120px] py-5">
+        <div className="flex flex-grow items-center">
+          <MainCraftIcon className="h-8 w-8" />
+          <span className="ml-2 text-xl font-bold">자세공작소</span>
+        </div>
+        <button
+          className="inline-flex items-center justify-center gap-2.5 rounded-[40px] bg-[#1F76F8] p-1 px-6 text-sm font-semibold leading-6 text-white"
+          onClick={loginHandler}
+        >
+          로그인
+        </button>
+      </div>
+      {/* contents */}
+      <div className="w-full bg-[#F5F5FA] px-[120px]"></div>
+    </div>
+  )
+}
+
+export default HomePage

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,4 @@
 import MainCraftIcon from "public/icons/posture-craft-side-nav-icon.svg?react"
-import { useEffect } from "react"
 
 const REST_API_KEY = import.meta.env.VITE_OAUTH_KAKAO_REST_API_KEY
 const REDIRECT_URI = import.meta.env.VITE_OAUTH_KAKAO_REDIRECT_URI

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,3 @@
 export { default as AuthPage } from "./AuthPage"
 export { default as MonitoringPage } from "./MonitoringPage"
+export { default as HomePage } from "./HomePage"

--- a/src/routes/AuthRoute.tsx
+++ b/src/routes/AuthRoute.tsx
@@ -1,7 +1,22 @@
 import React from "react"
+import { Navigate, Outlet } from "react-router-dom"
+import { useAuthStore } from "@/store/AuthStore"
+import RoutePath from "@/constants/routes.json"
 
-const AuthRoute = (): React.ReactElement => {
-  return <></>
+interface AuthRouteProps {
+  children?: React.ReactNode
+}
+
+const AuthRoute: React.FC<AuthRouteProps> = ({ children }) => {
+  const accessToken = useAuthStore((state) => state.accessToken)
+
+  // 토큰이 없거나 유효하지 않은 경우 홈으로 리다이렉트
+  if (!accessToken) {
+    return <Navigate to={RoutePath.HOME} replace />
+  }
+
+  // 토큰이 유효하다면 자식 컴포넌트 또는 Outlet을 렌더링
+  return children ? <>{children}</> : <Outlet />
 }
 
 export default AuthRoute

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,22 +1,25 @@
 import React from "react"
 import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom"
-import { AuthPage, MonitoringPage } from "@/pages"
+import { AuthPage, MonitoringPage, HomePage } from "@/pages"
 import { Layout } from "@/layouts"
 import RoutePath from "@/constants/routes.json"
+import AuthRoute from "@/routes/AuthRoute"
 
 const Router: React.FC = () => {
   return (
-    <>
-      <BrowserRouter>
-        <Routes>
-          <Route path={RoutePath.AUTH} element={<AuthPage />} />
-          <Route path="/" element={<Layout />}>
-            <Route index element={<MonitoringPage />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
+    <BrowserRouter>
+      <Routes>
+        <Route path={RoutePath.AUTH} element={<AuthPage />} />
+        <Route path="/" element={<HomePage />} />
+        <Route path="/" element={<Layout />}>
+          {/* AuthRoute로 보호된 경로를 감쌉니다 */}
+          <Route element={<AuthRoute />}>
+            <Route path={RoutePath.MONITORING} element={<MonitoringPage />} />
           </Route>
-        </Routes>
-      </BrowserRouter>
-    </>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
   )
 }
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,1 +1,2 @@
 export { default as Router } from "./Router"
+export { default as AuteRoute } from "./AuthRoute"

--- a/src/store/AuthStore.ts
+++ b/src/store/AuthStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand"
+
+interface AuthState {
+  isAuthenticated: boolean
+  user: any
+  accessToken: string
+  setUser: (user: any, accessToken: string) => void
+  logout: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isAuthenticated: false,
+  user: null,
+  accessToken: "",
+  setUser: (user: any, accessToken: string) =>
+    set({
+      user,
+      isAuthenticated: true,
+      accessToken,
+    }),
+  logout: () =>
+    set({
+      user: null,
+      isAuthenticated: false,
+      accessToken: "",
+    }),
+}))

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,1 @@
+export * from "./AuthStore"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
       "@components/*": ["src/components/*"],
       "@constants/*" : ["src/constants/*"],
       "@pages/*" : ["src/pages/*"],
-      "@layouts/*" : ["src/layouts/*"]
+      "@layouts/*" : ["src/layouts/*"],
+      "@store" : ["src/store/*"]
     }
   },
   "include": ["src", "svg.d.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,6 +529,18 @@
     "@svgr/hast-util-to-babel-ast" "8.0.0"
     svg-parser "^2.0.4"
 
+"@tanstack/query-core@5.51.21":
+  version "5.51.21"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.51.21.tgz#a510469c6c30d3de2a8b8798e340169a4b0fd08f"
+  integrity sha512-POQxm42IUp6n89kKWF4IZi18v3fxQWFRolvBA6phNVmA8psdfB1MvDnGacCJdS+EOX12w/CyHM62z//rHmYmvw==
+
+"@tanstack/react-query@^5.51.23":
+  version "5.51.23"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.51.23.tgz#83c223f4cb6054b206de8856b73ca7e41a63ba1f"
+  integrity sha512-CfJCfX45nnVIZjQBRYYtvVMIsGgWLKLYC4xcUiYEey671n1alvTZoCBaU9B85O8mF/tx9LPyrI04A6Bs2THv4A==
+  dependencies:
+    "@tanstack/query-core" "5.51.21"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz"
@@ -3326,6 +3338,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+use-sync-external-store@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
+  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
+
 util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
@@ -3469,3 +3486,10 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.5.tgz#f8c713041543715ec81a2adda0610e1dc82d4ad1"
+  integrity sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==
+  dependencies:
+    use-sync-external-store "1.2.2"


### PR DESCRIPTION
사용자 로그인 기능 추가 건입니다.

1. tanstack query, zustand 추가 
- yarn install 필요하며 useAuthMutation 훅 생성해서 사용합니다.
- AuthStore에 사용자 정보 저장 (accessToken 포함)

2. oauth 로그인 페이지 (AuthPage) 추가
- HomePage에서 로그인 버튼을 누르면 Kakao Oauth 로그인 실행합니다. 
- 홈페이지 디자인은 아직 완성이되지 않아 완성되면 반영 예정입니다.

3. .env 및 .env.local 파일 추가
- git에 반영되지 않아서 직접 추가 필요합니다. (Kakao Key 및 API base url)

4. AuthRoute 
- 인증이 반드시 필요한 페이지는 AuthRoute 내부에 등록

추가적으로 인증 이후 사용자 정보와 accessToken을 zustand store에 저장하는데,
새로고침 등으로 사용자 정보가 날라간 경우 다시 불러오는 정책을 정해야 할 것 같습니다. (localStorage 혹은 cookie)